### PR TITLE
In lua, "hashtab[key] = nil" does not physically delete the entry associ...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,7 +101,9 @@ Creates a new cache instance. If failed, returns `nil` and a string describing t
 
 The `max_items` argument specifies the maximal number of items held in the cache.
 The `load-factor` argument designates the load-factor of the hash-table used internally;
-the default value is 0.5 (i.e. 50%), and any insane value will be clamped to the range of [0.25, 1].
+the default value is 0.5 (i.e. 50%); if the load-factor is specified, it will be clamped
+to the range of `[0.1, 1]` (i.e. if load-factor is greater than 1, it will be saturated to
+1; likewise, if load-factor is smaller than `0.1`, it will be clamped to `0.1`).
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/resty/lrucache.lua
+++ b/lib/resty/lrucache.lua
@@ -26,21 +26,21 @@ local crc_tab = ffi.new("const unsigned int[256]", {
     0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D, 0x76DC4190, 0x01DB7106,
     0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
     0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D,
-    0x91646C97, 0xE6635C01, 0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 
+    0x91646C97, 0xE6635C01, 0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E,
     0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457, 0x65B0D9C6, 0x12B7E950,
     0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
     0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7,
     0xA4D1C46D, 0xD3D6F4FB, 0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0,
     0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9, 0x5005713C, 0x270241AA,
     0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
-    0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 
+    0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81,
     0xB7BD5C3B, 0xC0BA6CAD, 0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A,
     0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683, 0xE3630B12, 0x94643B84,
     0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
     0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB,
     0x196C3671, 0x6E6B06E7, 0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC,
     0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5, 0xD6D6A3E8, 0xA1D1937E,
-    0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B, 
+    0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
     0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55,
     0x316E8EEF, 0x4669BE79, 0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236,
     0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F, 0xC5BA3BBE, 0xB2BD0B28,
@@ -54,7 +54,7 @@ local crc_tab = ffi.new("const unsigned int[256]", {
     0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB, 0xAED16A4A, 0xD9D65ADC,
     0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
     0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693,
-    0x54DE5729, 0x23D967BF, 0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 
+    0x54DE5729, 0x23D967BF, 0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94,
     0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D });
 
 local setmetatable = setmetatable
@@ -195,9 +195,12 @@ end
 
 -- "size" specifies the maximum number of entries in the LRU queue, and the
 -- "load_factor" designates the 'load factor' of the hash-table we are using
--- internally. The default value of load-factor is 0.5 (i.e. 50%) and is
--- clamped to the range [0.25, 1].
---
+-- internally. The default value of load-factor is 0.5 (i.e. 50%); if the
+-- load-factor is specified, it will be clamped to the range of [0.1, 1](i.e.
+-- if load-factor is greater than 1, it will be saturated to 1, likewise,
+-- if load-factor is smaller than 0.1, it will be clamped to 0.1).
+-- 
+
 function _M.new(size, load_factor)
     if size < 1 then
         return nil, "size too small"
@@ -209,8 +212,8 @@ function _M.new(size, load_factor)
         load_f = 0.5
     elseif load_factor > 1 then
         load_f = 1
-    elseif load_factor < 0.25 then
-        load_f = 0.25
+    elseif load_factor < 0.1 then
+        load_f = 0.1
     end
 
     local bs_min = size / load_f
@@ -242,6 +245,7 @@ function _M.new(size, load_factor)
     return setmetatable(self, mt)
 end
 
+
 local function crc32_ptr(ptr)
     local crc32 = 0;
 
@@ -259,6 +263,7 @@ local function crc32_ptr(ptr)
     --crc32 = bxor(brshift(crc32, 8), crc_tab[band(bxor(crc32, b), 255)])
     return crc32
 end
+
 
 local function hash_string(self, str)
     local c_str = ffi_cast(c_str_t, str)
@@ -288,11 +293,13 @@ local function _find_node_in_bucket(key, key_v, node_v, bucket_hdr_id)
     end
 end
 
+
 local function find_key(self, key)
     local key_hash = hash_string(self, key)
     return _find_node_in_bucket(key, self.key_v, self.node_v,
                                 self.bucket_v[key_hash])
 end
+
 
 -- Return the index of the node associated with the key, or nil if the node
 -- was not found.
@@ -324,6 +331,7 @@ local function remove_key(self, key)
     end
 end
 
+
 local function insert_key(self, key, val, node)
     local node_id = node.id
     self.key_v[node_id] = key
@@ -336,9 +344,10 @@ local function insert_key(self, key, val, node)
     bucket_v[key_hash] = node.id
 end
 
+
 function _M.get(self, key)
     if type(key) ~= "string" then
-        return nil
+        key = tostring(key)
     end
 
     local node_id = find_key(self, key)
@@ -363,7 +372,7 @@ end
 
 function _M.delete(self, key)
     if type(key) ~= "string" then
-        return nil
+        key = tostring(key)
     end
 
     local node_id = remove_key(self, key);
@@ -380,7 +389,7 @@ end
 
 function _M.set(self, key, value, ttl)
     if type(key) ~= "string" then
-        return nil
+        key = tostring(key)
     end
 
     local node_id = find_key(self, key)
@@ -413,5 +422,6 @@ function _M.set(self, key, value, ttl)
         node.expire = -1
     end
 end
+
 
 return _M


### PR DESCRIPTION
...ated with the key.

So, if key keeps changing, the table size keeps changing as well, which leads to horrible
performance.

This change implements a hash-tab to render it possible to erase a entry immeidately if
it is becoming dead. The hash function is using CRC32, which seems to be working quite
well.
