### PR TITLE
Fix a bug in pureffi.lua.

### DIFF
--- a/lib/resty/lrucache/pureffi.lua
+++ b/lib/resty/lrucache/pureffi.lua
@@ -417,6 +417,7 @@ function _M.set(self, key, value, ttl)
         insert_key(self, key, value, node)
     else
         node = self.node_v + node_id
+        self.val_v[node_id] = value
     end
 
     queue_remove(node)


### PR DESCRIPTION
The problem is that it is not able to update the value associated
with a key if the old value associated with the key is not yet
evicited (regardless the key/value pair expires or not).
