### PR TITLE
lrucache.set and  lrucache.delete add destructor, in case of memory leak

### DIFF
--- a/lib/resty/lrucache.lua
+++ b/lib/resty/lrucache.lua
@@ -161,7 +161,11 @@ function _M.get(self, key)
 end
 
 
-function _M.delete(self, key)
+function _M.delete(self, key, destructor)
+    if self.hasht[key] and destructor then
+        destructor(self.hasht[key])
+    end
+
     self.hasht[key] = nil
 
     local key2node = self.key2node
@@ -179,8 +183,8 @@ function _M.delete(self, key)
     return true
 end
 
-
-function _M.set(self, key, value, ttl)
+-- destructor is used to cleanup the old value
+function _M.set(self, key, value, ttl, destructor)
     local hasht = self.hasht
     hasht[key] = value
 
@@ -199,6 +203,10 @@ function _M.set(self, key, value, ttl)
             -- print(key, ": evicting oldkey: ", oldkey, ", oldnode: ",
             --         tostring(node))
             if oldkey then
+                if hasht[oldkey] and destructor then
+                    destructor(hasht[oldkey])
+                end
+                
                 hasht[oldkey] = nil
                 key2node[oldkey] = nil
             end


### PR DESCRIPTION
lrucache.get method return old value if avaliable. 
But if free_queue is empty, old value won't be returned. 
If the value set in lrucache need to be freed, please use destructor when you invoke lrucache.set;

Note: 
destructor is used to free old value, not current.