### PR TITLE
travis-ci: upgraded nginx core to 1.13.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ env:
     - LD_LIBRARY_PATH=$LUAJIT_LIB:$LD_LIBRARY_PATH
     - TEST_NGINX_SLEEP=0.006
   matrix:
-    - NGINX_VERSION=1.9.15
-    - NGINX_VERSION=1.11.2
+    - NGINX_VERSION=1.13.6
 
 install:
   - if [ ! -d download-cache ]; then mkdir download-cache; fi


### PR DESCRIPTION
lua-nginx-module and lua-resty-core are using `1.13.6` exclusively, hence why I removed the previous versions.