### PR TITLE
get returns remaining ttl

### DIFF
--- a/lib/resty/lrucache.lua
+++ b/lib/resty/lrucache.lua
@@ -174,7 +174,7 @@ function _M.get(self, key)
         -- print("expired: ", node.expire, " > ", ngx_now())
         return nil, val
     end
-    return val
+    return val, node.expire - ngx.now()
 end
 
 


### PR DESCRIPTION
lru.get() returns the remaining ttl on success. Comparable to ngx.shared.DICT.ttl altough integrated directly into the get function. 
Could change it to a standalone function if that's preferable. 