### PR TITLE
Optimize: echo warning message  when install this library to "/usr/local/lib/lua/"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 OPENRESTY_PREFIX=/usr/local/openresty
 
+LUA_VERSION := 5.1
 PREFIX ?=          /usr/local
 LUA_INCLUDE_DIR ?= $(PREFIX)/include
-LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
+LUA_LIB_DIR ?=     $(PREFIX)/share/lua/$(LUA_VERSION)
 INSTALL ?= install
 
 .PHONY: all test install lint

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 OPENRESTY_PREFIX=/usr/local/openresty
 
-LUA_VERSION := 5.1
 PREFIX ?=          /usr/local
 LUA_INCLUDE_DIR ?= $(PREFIX)/include
-LUA_LIB_DIR ?=     $(PREFIX)/share/lua/$(LUA_VERSION)
+LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
 INSTALL ?= install
+
+SHELL:=/bin/bash
 
 .PHONY: all test install lint
 
@@ -14,6 +15,13 @@ install: all
 	$(INSTALL) -d $(DESTDIR)/$(LUA_LIB_DIR)/resty/lrucache
 	$(INSTALL) lib/resty/*.lua $(DESTDIR)/$(LUA_LIB_DIR)/resty/
 	$(INSTALL) lib/resty/lrucache/*.lua $(DESTDIR)/$(LUA_LIB_DIR)/resty/lrucache/
+ifeq ($(LUA_LIB_DIR),/usr/local/lib/lua/)
+	@echo
+	@echo -e "\033[33mPLEASE NOTE: \033[0m"
+	@echo -e "\033[33mThe necessary lua_package_path directive needs to be added to nginx.conf\033[0m"
+	@echo -e "\033[33min the http context, because \"/usr/local/lib/lua/\" is not in LuaJIT’s default search path.\033[0m"
+	@echo -e "\033[33mRefer to the Installation section of README.markdown.\033[0m"
+endif
 
 test: all lint
 	PATH=$(OPENRESTY_PREFIX)/nginx/sbin:$$PATH prove -I../test-nginx/lib -r t


### PR DESCRIPTION
the default install path is '/usr/local/lib/lua/', which is not the default search path of LuaJIT.
so we should add some warning messages to remind users to add necessary configurations in the nginx configuration file